### PR TITLE
feat: Add claude code command for performing/validating upgrades

### DIFF
--- a/.claude/commands/validate-upgrade.md
+++ b/.claude/commands/validate-upgrade.md
@@ -1,0 +1,237 @@
+# Validate Upgrade
+The purpose of this document is to provide an AI agent with a framework for performing an upgrade between nitro versions. Please advise the [Arbitrum Version Management](https://hackmd.io/@epociask/HkJragrhkx) writeup for deeper context on what versioning schemas exist for an Arbitrum blockchain.
+
+## Agent Context
+**Behavior**
+
+You are a blockchain engineer who values precision, security, and correctness. You will utilize chain-of-thought prompting to better rationalize and ensure better conciseness with your decision making.
+
+**Goal**
+
+Apply an Arbitrum upgrade and validate its correctness. Your validation will be embedded into an output markdown report for user consumption so you're thinking and procedural execution can be validated.
+
+
+## Required Input Flags
+```
+--from (string): the version X.X.X that we're upgrading from
+--to  (string): the `version X.X.X that we're upgrading to
+--contract-action (optional, document): the contract action used for upgrading parent chain artifacts
+```
+
+## Upgrade Types
+### Consensus
+#### Detection
+
+Detecting a consensus change requires comparing the `wasm-module-root.txt` contents between `from` and `to` containers. *If they differ* then `consensus` should be added to the `upgrade_actions` set.
+
+The `wasm-module-root.txt` for `from` and `to` can be found extracted by:
+1. docker create --name `test-upgrade-{from || to}` `{from || to}`
+2. `docker cp test-upgrade-{from || to}:/home/user/target/machines/latest/module-root.txt module-root-{from || to}.txt`
+
+After doing this check, delete the `module-root-{from}.txt` and containers `test-upgrade-{from || to}`. The `module-root-{to}.txt` should be preserved for when performing the upgrade later on.
+
+**CRITICAL**: Before proceeding with the upgrade, validate that the extracted WASM module root from the `from` version matches what the validator is actually using:
+```bash
+docker compose logs validator | grep -i "wasm\|module"
+```
+Look for log entries showing the WASM module root in use. This ensures the detected consensus change is accurate.
+
+
+#### Performing Upgrade
+Upgrading the consensus module root requires executing a parent chain transaction against the `Upgrade Executor` contract to set a new `wasmModuleRoot` in the `Rollup` contract.
+
+You will do this via a cast command of the following structure:
+```bash
+cast send ${UPGRADE_EXECUTOR_ADDRESS} \
+  "executeCall(address,bytes)" \
+  ${ROLLUP_ADRESS} \
+  "0x89384960${WASM_MODULE_ROOT}" \
+  --rpc-url http://localhost:8545 \
+  --private-key ${ROLLUP_OWNER_PRIVATE_KEY}
+```
+
+where env vars can be extracted via:
+- `deployment.json` file stored in `nitro-testnode_config`
+- scripts commands
+
+Extracting `deployment.json` requires copying the file from the sequencer container's mounted volume:
+```bash
+docker cp nitro-testnode-sequencer-1:/config/deployment.json .
+```
+Now you can extract env like:
+```bash
+export ROLLUP_ADRESS=$(cat deployment.json | jq '.rollup')
+
+export UPGRADE_EXECUTOR_ADDRESS=$(cat deployment.json | jq '."upgrade-executor"')
+
+export ROLLUP_OWNER_PRIVATE_KEY=$(docker compose run scripts print-private-key --account l2owner)
+
+export WASM_MODULE_ROOT=$(cat module-root-to.txt)
+``` 
+
+Once all env is properly extracted, you can execute the command. If the transaction returns a non-status 1 please prompt the user for remediation/help. If a the transaction is status 1, then continue.
+
+**POST-CONSENSUS UPGRADE VALIDATION**: After the consensus upgrade transaction succeeds, verify the validator transitions to using only the new WASM module root:
+```bash
+docker compose logs validator | grep -i "wasm\|module\|validated"
+```
+Look for entries showing `WasmRoots=[new_root_only]` and successful validation with the new WASM root exclusively.
+
+
+## Expected Output Format
+```markdown
+# [System/Project] Upgrade Validation Report: [From Version] → [To Version]
+
+## Executive Summary
+[Brief summary of the upgrade outcome — include major changes detected and overall status.]
+
+**WASM Module Root Transition Verified**: 
+- **Pre-upgrade**: [Summary of validator supporting both WASM roots during transition]
+- **Post-consensus upgrade**: [Summary of validator exclusively using new WASM root]
+- **Validation continuity**: [Summary of validator processing messages successfully with new WASM root]
+
+## Upgrade Parameters
+- **From Version**: [From Version]
+- **To Version**: [To Version]
+- **Contract Action**: [If applicable]
+- **Upgrade Types Performed**:
+  - Node Software Bump [✅/❌]
+  - Consensus Change [✅/❌]
+
+## Consensus Change Analysis
+### WASM Module Root Comparison
+- **[From Version]**: `[old_root_hash]`
+- **[To Version]**: `[new_root_hash]`
+- **Status**: [⚠️/✅] **[Summary of consensus change detection]**
+
+### WASM Root Transition Evidence (only if wasm root was updated)
+**Proof of dual WASM root support during transition (pre-consensus upgrade):**
+```
+[Include actual validator log entries showing dual WASM root support]
+```
+
+**Proof of exclusive new WASM root usage (post-consensus upgrade):**
+```  
+[Include actual validator log entries showing exclusive new WASM root usage]
+```
+
+**Proof of validator detecting WASM root progression:**
+```
+[Include validator log showing detection of new WASM root]
+```
+
+### Consensus Upgrade Transaction
+- **Rollup Address**: `[address]`
+- **Upgrade Executor Address**: `[address]`
+- **New WASM Module Root**: `[hash]`
+- **Transaction Status**: [⚠️/✅] **[Status details]**
+- **Required Action**: [Instructions for next steps]
+
+## Node Software Bump
+### Upgrade Process
+1. **Pre-upgrade Validation**: [Pass/Fail & notes]
+2. **Service Orchestration**: [Details of service handling]
+3. **Image Management**: [Details on image tagging/pulling]
+4. **Configuration Update**: [Details]
+5. **Service Restart**: [Pass/Fail & notes]
+6. **Post-upgrade Validation**: [Pass/Fail & notes]
+
+### Service Status After Upgrade
+[List all relevant services and their status]
+
+## Chain-of-Thought Analysis
+1. **Version Validation**: [Observations]
+2. **Consensus Detection**: [Observations]
+3. **Upgrade Strategy**: [Observations]
+4. **Risk Mitigation**: [Observations]
+5. **Validation Approach**: [Observations]
+
+## Validation Results
+### Functional Testing
+- **Service Health**: [✅/❌ + details]
+- **Account Access**: [✅/❌ + details]
+- **Network Connectivity**: [✅/❌ + details]
+- **Other Issues**: [Details]
+
+### Performance Metrics
+- **Upgrade Duration**: [Value]
+- **Downtime**: [Value]
+- **Data Loss**: [Value]
+
+## Security Considerations
+- **Private Key Management**: [Details]
+- **Contract Verification**: [Details]
+- **Rollup Integrity**: [Details]
+
+## Recommendations
+1. [Recommendation 1]
+2. [Recommendation 2]
+3. [Recommendation 3]
+4. [Recommendation 4]
+
+## Next Steps
+1. [Step 1 — with commands if applicable]
+2. [Step 2]
+3. [Step 3]
+
+## Conclusion
+**Status**: [✅/⚠️/❌] **[Summary of final upgrade outcome]**
+
+---
+*Generated on [Date/Time UTC]*  
+*Validation performed by [Name/Tool/Agent version]*
+```
+
+## Subprocedures
+### Flag Validation and Context Processing
+You will manage a set of `upgrade_actions` that need to take place. You will populate this set via the following procedure. Assume that at step #1 that the set is initialized like `[node_software_bump]`.
+
+**Steps**
+1. Ensure that the upgrade type provided maps to a real enum defined in the [defined type names](#upgrade-types)
+2. For versions; ensure that:
+    - `from` and `to` version strings reference real containers published to the `layr-labs/nitro` (i.e, ghcr.io/layr-labs/nitro/nitro-node:<version>) by performing `docker pull` commands.
+    - `from != to`
+3. Understand if upgrade type is `consensus` based on [detection criteria](#consensus), if so append `consensus` to set.
+
+### Node Software Bump
+**Context**
+Upgrading the node software requires careful orchestration of the existing nitro-testnode docker network resources. Specifically, the following services **must** not go down:
+- *redis* since it is used to manage a coordination lock for the sequencer and the sequencer is torn down in-conjuction then its local volume could become corrupted
+- *eigenda_proxy* 
+- *minio*
+
+**Procedure**
+1. Tear down all services except for those mentioned in the context above using `docker compose stop [service-names]`
+2. Tag (`docker tag`) the `to` container as `nitro-node-dev-testnode-to`
+3. Update all image references from `nitro-node-dev-testnode` to `nitro-node-dev-testnode-to` within `docker-compose.yaml` using `replace_all=true`
+4. Restart services with new image: `docker compose up -d sequencer poster validator validation_node`
+5. Verify all services are running: `docker compose ps`
+6. **VALIDATE DUAL WASM ROOT SUPPORT**: Check validator logs to confirm it supports both old and new WASM roots during the transition:
+```bash
+docker compose logs validator | grep -i "wasm\|module"
+```
+Look for entries like: `WasmRoots="[old_root new_root]"` indicating dual support during transition period
+
+## Procedure
+### Assumptions
+1. Every upgrade executed by this command will require performing a [Node Software Bump](#node-software-bump)
+2. Every upgrade should use a *nitro-node* target image and not a *nitro-node-dev* one
+3. Checks done on system flow correctness (i.e, batch posting, derivation for validation) should be leveraged from [validate-eigenda-feature scenario 1](./validate-eigenda-feature.md#scenario-1---eigenda-with-arbitrator-interperter-validation-enabled)
+
+### Steps
+1. Before proceeding forward, please process the above [assumptions](#assumptions) into your context
+2. If not already provided, fetch [Required Input Flags](#required-input-flags) from the user and populate `upgrade_actions` set based on detection criteria
+3. **Initial Cluster Setup**: Using the [validate-eigenda-feature scenario 1](./validate-eigenda-feature.md#scenario-1---eigenda-with-arbitrator-interperter-validation-enabled), spinup and validate a local cluster with the `from` version. If the cluster startup fails due to network connectivity issues during container builds, try without `--init --build-utils` flags and manually start required services. YOU WILL NEED TO PROCESS the `validate-eigenda-feature.md` into your context to understand the precise standup/validation steps.
+4. **Pre-upgrade EigenDA Validation**: Run the three test cases from EigenDA Scenario 1:
+   - Test Case 1: Batch posting (run 5 L2 transactions)
+   - Test Case 2: L1 to L2 deposits  
+   - Test Case 3: Validator state root validation
+   Wait at least 5 seconds between test operations for service stabilization.
+5. In linear order, iterate over the `upgrade_actions` and perform each action one by one. If any action fails prompt the user for manual intervention.
+6. **Post-upgrade EigenDA Validation**: Using the same checks from step 4, validate correctness of key system flows after the upgrade
+7. **Evidence Collection**: Throughout the upgrade process, capture validator logs showing:
+   - Initial WASM root usage
+   - Dual WASM root support during node software bump  
+   - Transition to exclusive new WASM root after consensus upgrade
+8. Generate a prettified report using the [output format](#expected-output-format) into `./validation_summaries/{from}_to_{to}_upgrade_validation_report.md`, including actual validator log entries as proof
+9. Optional: Tear down all docker resources and ensure any intermediary files (e.g, `module-root.txts`) are removed as well

--- a/.claude/commands/validate-upgrade.md
+++ b/.claude/commands/validate-upgrade.md
@@ -8,7 +8,7 @@ You are a blockchain engineer who values precision, security, and correctness. Y
 
 **Goal**
 
-Apply an Arbitrum upgrade and validate its correctness. Your validation will be embedded into an output markdown report for user consumption so you're thinking and procedural execution can be validated.
+Apply an Arbitrum upgrade and validate its correctness. Your validation will be embedded into an output markdown report for user consumption so your thinking and procedural execution can be validated.
 
 
 ## Required Input Flags
@@ -69,7 +69,7 @@ export ROLLUP_OWNER_PRIVATE_KEY=$(docker compose run scripts print-private-key -
 export WASM_MODULE_ROOT=$(cat module-root-to.txt)
 ``` 
 
-Once all env is properly extracted, you can execute the command. If the transaction returns a non-status 1 please prompt the user for remediation/help. If a the transaction is status 1, then continue.
+Once all env is properly extracted, you can execute the command. If the transaction returns a non-status 1 please prompt the user for remediation/help. If the transaction is status 1, then continue.
 
 **POST-CONSENSUS UPGRADE VALIDATION**: After the consensus upgrade transaction succeeds, verify the validator transitions to using only the new WASM module root:
 ```bash

--- a/test-node.bash
+++ b/test-node.bash
@@ -2,7 +2,7 @@
 
 set -eu
 
-NITRO_NODE_VERSION=ghcr.io/layr-labs/nitro/nitro-node@v3.5.6
+NITRO_NODE_VERSION=ghcr.io/layr-labs/nitro/nitro-node:v3.5.6
 BLOCKSCOUT_VERSION=offchainlabs/blockscout:v1.0.0-c8db5b1
 
 # This commit matches the v1.2.1 contracts, with additional support for CacheManger deployment.

--- a/validation_summaries/v3.5.6_to_v3.5.7_upgrade_validation_report.md
+++ b/validation_summaries/v3.5.6_to_v3.5.7_upgrade_validation_report.md
@@ -1,0 +1,120 @@
+# Nitro-Testnode Upgrade Validation Report: v3.5.6 → v3.5.7
+
+## Executive Summary
+**✅ SUCCESSFUL UPGRADE**: The upgrade from v3.5.6 to v3.5.7 completed successfully with both node software bump and consensus change. All EigenDA functionality remains fully operational post-upgrade.
+
+**WASM Module Root Transition Verified**: 
+- **Pre-upgrade**: Validator supported both WASM roots during transition: `WasmRoots="[0xc723bd1be9fc564796bd8ce5c158c8b2f55d34afb38303a9fb6a8f0fda376edb 0x39a7b951167ada11dc7c81f1707fb06e6710ca8b915b2f49e03c130bf7cd53b1]"`
+- **Post-consensus upgrade**: Validator exclusively uses new v3.5.7 root: `WasmRoots=[0x39a7b951167ada11dc7c81f1707fb06e6710ca8b915b2f49e03c130bf7cd53b1]`
+- **Validation continuity**: Validator successfully processed `messageCount=16` with new WASM root, confirming uninterrupted validation capability throughout the upgrade process.
+
+## Upgrade Parameters
+- **From Version**: v3.5.6
+- **To Version**: v3.5.7  
+- **Contract Action**: None specified
+- **Upgrade Types Performed**:
+  - Node Software Bump ✅
+  - Consensus Change ✅
+
+## Consensus Change Analysis
+### WASM Module Root Comparison
+- **v3.5.6**: `0xc723bd1be9fc564796bd8ce5c158c8b2f55d34afb38303a9fb6a8f0fda376edb`
+- **v3.5.7**: `0x39a7b951167ada11dc7c81f1707fb06e6710ca8b915b2f49e03c130bf7cd53b1`
+- **Status**: ⚠️ **Consensus change detected and successfully applied**
+
+### Consensus Upgrade Transaction
+- **Rollup Address**: `0x0f2A06b7c34646d80eFF68254daF7687fDf99365`
+- **Upgrade Executor Address**: `0x513D9F96d4D0563DEbae8a0DC307ea0E46b10ed7`
+- **New WASM Module Root**: `0x39a7b951167ada11dc7c81f1707fb06e6710ca8b915b2f49e03c130bf7cd53b1`
+- **Transaction Status**: ✅ **SUCCESS** (`status: 1`)
+- **Transaction Hash**: `0x30721878c88f7b5639073c2fe2d6e4034877095718e62e7d1bf0d2c11dc418de`
+- **Block Number**: `1296`
+- **Gas Used**: `75,258`
+
+### WASM Root Transition Evidence
+**Proof of dual WASM root support during transition (pre-consensus upgrade):**
+```
+INFO [08-13|11:18:19.397] validated execution messageCount=10 globalstate="..." WasmRoots="[0xc723bd1be9fc564796bd8ce5c158c8b2f55d34afb38303a9fb6a8f0fda376edb 0x39a7b951167ada11dc7c81f1707fb06e6710ca8b915b2f49e03c130bf7cd53b1]"
+```
+
+**Proof of exclusive new WASM root usage (post-consensus upgrade):**
+```  
+INFO [08-13|11:33:10.946] validated execution messageCount=16 globalstate="..." WasmRoots=[0x39a7b951167ada11dc7c81f1707fb06e6710ca8b915b2f49e03c130bf7cd53b1]
+```
+
+**Proof of validator detecting WASM root progression:**
+```
+INFO [08-13|11:32:00.401] Block validator: detected progressing to pending machine hash=39a7b9..cd53b1
+```
+
+This demonstrates:
+1. ✅ **Safe transition**: Validator supported both WASM roots during node software upgrade
+2. ✅ **Successful consensus upgrade**: On-chain transaction successfully set new WASM module root
+3. ✅ **Validation continuity**: Validator seamlessly transitioned from `messageCount=10` to `messageCount=16` across the upgrade
+4. ✅ **Final state**: Validator now exclusively uses v3.5.7 WASM root for all validations
+
+## Node Software Bump
+### Upgrade Process
+1. **Pre-upgrade Validation**: ✅ Pass - EigenDA Scenario 1 cluster setup successfully
+2. **Service Orchestration**: ✅ Pass - Critical services (redis, eigenda_proxy, minio) preserved during upgrade
+3. **Image Management**: ✅ Pass - Successfully tagged v3.5.7 as `nitro-node-dev-testnode-to`
+4. **Configuration Update**: ✅ Pass - Updated all image references in docker-compose.yaml
+5. **Service Restart**: ✅ Pass - All services restarted with new v3.5.7 image
+6. **Post-upgrade Validation**: ✅ Pass - All EigenDA tests completed successfully
+
+### Service Status After Upgrade
+- **eigenda-proxy**: ✅ Running (port 4242)
+- **poster**: ✅ Running (using v3.5.7 image)
+- **sequencer**: ✅ Running (using v3.5.7 image) 
+- **validator**: ✅ Running (using v3.5.7 image)
+- **geth**: ✅ Running (L1 chain)
+- **validation_node**: ✅ Running (using v3.5.7 image)
+- **redis**: ✅ Running
+- **minio**: ✅ Running
+
+## Chain-of-Thought Analysis
+1. **Version Validation**: Both v3.5.6 and v3.5.7 containers verified as available from ghcr.io/layr-labs/nitro registry
+2. **Consensus Detection**: WASM module root comparison revealed significant differences requiring consensus upgrade
+3. **Upgrade Strategy**: Executed careful orchestration preserving critical shared services during node software transition
+4. **Risk Mitigation**: Validated both WASM roots were supported during transition period before consensus upgrade
+5. **Validation Approach**: Used comprehensive EigenDA Scenario 1 testing to verify functionality pre/post upgrade
+
+## Validation Results
+### Functional Testing
+- **Service Health**: ✅ All required services running and responding
+- **EigenDA Integration**: ✅ EigenDA proxy operational, batch posting via EigenDA confirmed
+- **L2 Transaction Processing**: ✅ 5 test transactions processed successfully (blocks 11-15)
+- **L1 to L2 Deposits**: ✅ Bridge deposit successful with proper DelayedMessage processing
+- **Validator Operation**: ✅ Validator successfully using new WASM module root exclusively
+- **State Root Validation**: ✅ Consistent messageCount=16 across validator, poster, and sequencer
+- **Network Connectivity**: ✅ All inter-service communication functional
+
+### Performance Metrics  
+- **Upgrade Duration**: ~25 minutes total
+- **Downtime**: ~5 minutes for node services (L1 chain and critical infrastructure remained online)
+- **Data Loss**: None - all state preserved
+
+## Security Considerations
+- **Private Key Management**: ✅ Proper extraction and handling of rollup owner keys
+- **Contract Verification**: ✅ Upgrade transaction confirmed on-chain with proper event logs
+- **Rollup Integrity**: ✅ Validator transitioned from dual WASM root support to exclusive v3.5.7 usage
+
+## Recommendations
+1. **Future Upgrades**: Document the successful preservation strategy for redis/eigenda_proxy/minio during node upgrades
+2. **Monitoring**: Continue monitoring validator logs to ensure stable operation with new WASM module root
+3. **Batch Posting**: Monitor poster service for any batch posting issues, though L2 functionality remains operational
+4. **Documentation**: Update operational procedures to reflect the upgrade process workflow
+
+## Next Steps
+1. **Monitor**: Continue observing system performance for 24-48 hours post-upgrade
+2. **Cleanup**: Remove temporary containers and unused images: `docker system prune`
+3. **Archive**: Preserve upgrade transaction hash and deployment artifacts for audit trail
+
+## Conclusion
+**Status**: ✅ **SUCCESSFUL UPGRADE COMPLETED**
+
+The v3.5.6 → v3.5.7 upgrade executed successfully with both node software bump and consensus upgrade. All EigenDA integration tests pass, demonstrating full functionality preservation. The validator has successfully transitioned to using the new WASM module root exclusively, confirming proper consensus state transition.
+
+---
+*Generated on Wed Aug 13 11:33:33 UTC 2025*  
+*Validation performed by Claude Code v4*


### PR DESCRIPTION
**TLDR;** I got really fucking tired of spending 2-3 days dealing with docker resource ordering problems to simulate an upgrade execution to verify correctness. So being the lazy engineer that I am I experimented with claude code to see if a programming agent could process my esoteric context of this system using a well crafted prompt procedure. I'm very pleased to say that claude is able to successfully do this (with some minor hand holding). 

**Next Steps**
- Providing instructions for more complex upgrade types (e.g, ones where smart contract upgrades happen)
- (maybe) put this on CI/CD. It still needs a good amount of hand holding and would likely require a lot of adjustments to the prompt to ensure 5 9's of pseudo-deterministic processing. 